### PR TITLE
Fix FIREBASE_$VAR .env Naming

### DIFF
--- a/src/content/docs/en/guides/backend/google-firebase.mdx
+++ b/src/content/docs/en/guides/backend/google-firebase.mdx
@@ -29,9 +29,9 @@ See our separate guide for [deploying to Firebase hosting](/en/guides/deploy/goo
 To add your Firebase credentials to Astro, create an `.env` file in the root of your project with the following variables:
 
 ```ini title=".env"
-FIREBASE_PRIVATE_KEY_ID=YOUR_SPACE_ID
-FIREBASE_PRIVATE_KEY=YOUR_DELIVERY_TOKEN
-FIREBASE_PROJECT_ID=YOUR_PREVIEW_TOKEN
+FIREBASE_PRIVATE_KEY_ID=YOUR_PRIVATE_KEY_ID
+FIREBASE_PRIVATE_KEY=YOUR_PRIVATE_KEY
+FIREBASE_PROJECT_ID=YOUR_PROJECT_ID
 FIREBASE_CLIENT_EMAIL=YOUR_CLIENT_EMAIL
 FIREBASE_CLIENT_ID=YOUR_CLIENT_ID
 FIREBASE_AUTH_URI=YOUR_AUTH_URI


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

**- Minor content fixes (broken links, typos, etc.)**

#### Description

- What does this PR change? Give us a brief description.
Rename of placeholder variables for Firebase `.env` so the user isn't left wondering why we're mapping `PRIVATE_KEY_ID ` to `YOUR_SPACE_ID`, etc.

- Did you change something visual? A before/after screenshot can be helpful.
Nope!

<!-- Are these docs for an upcoming Astro release? -->
<!-- Uncomment the line below and fill in the future Astro version and link the relevant `withastro/astro` PR.  -->
<!-- #### For Astro version: `version`. See [Astro PR #](url). -->

<!--
Here’s what will happen next:

1. Our GitHub bots will run to check your changes.
   If they spot any broken links you will see some error messages on this PR.
   Don’t hesitate to ask any questions if you’re not sure what these mean!

2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳

3. One or more of our maintainers will take a look and may ask you to make changes.
   We try to be responsive, but don’t worry if this takes a day or two.
-->
